### PR TITLE
Fix bower ignoring less src files

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "uw-ui-toolkit",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "homepage": "https://github.com/UWMadisonUcomm/uw-ui-toolkit",
   "authors": [
     "UW-Madison University Communications"
@@ -28,11 +28,11 @@
     "_layouts",
     "_plugins",
     "doc-assets",
-    "documentation",
-    "examples",
-    "getting-started",
-    "my-uw",
-    "ui-components",
+    "./documentation",
+    "./examples",
+    "./getting-started",
+    "./my-uw",
+    "./ui-components",
     "config.json",
     ".bundle",
     ".ruby-version",


### PR DESCRIPTION
In the previous changeset I added folders to ignore in bower.json that were irrelevant for end users. 'my-uw' and 'examples' inadvertently made bower ignore these folders under src/less in addition to the 'my-uw' and 'examples' folders in the root. This hopefully fixes that.