### PR TITLE
Issue #62: Release to Maven Central, change groupId

### DIFF
--- a/README-Maven.md
+++ b/README-Maven.md
@@ -1,24 +1,24 @@
 ## Maven Support
 
-A Maven pom is provided to allow us to publish this artifact to the [Shared Tools Maven Artifact Repository](https://wiki.doit.wisc.edu/confluence/display/ST/Maven+Repository+Manager).
+A Maven pom is provided to allow us to publish this artifact to [Maven Central](http://search.maven.org).
   
 This pom is modeled after the poms used by the [WebJars Project](http://www.webjars.org/). 
 
 ### Maven Dependency Information
 
-The dependency can then be referenced via:
+Adding this project to your existing Maven projects is as simple as adding the following to your `<dependencies>`:
 
     <dependency>
-      <groupId>edu.wisc.uc</groupId>
+      <groupId>edu.wisc.umark</groupId>
       <artifactId>uw-ui-toolkit</artifactId>
-      <version>0.2.0</version>
+      <version>0.2.2</version>
     </dependency>
-    
--SNAPSHOTS and releases are published in the Shared Tools *Public Releases* repository.
 
 ### Local Maven Build How To
 
-If you have local modifications you need to depend on, and want to install locally, simply execute to create a jar and install
+*This step is not necessary for most use cases.*
+
+If you have local modifications of this project you need to depend on, and want to install locally, simply execute to create a jar and install
 it in your local maven repository:
 
     mvn install
@@ -27,20 +27,18 @@ Requires Maven be installed and on your PATH.
 Maven will download the specified release from github (controlled via the *upstreamVersion* property), unpack it into
 the target directory, and repack with the folders in the correct locations per the Servlet 3.0 Resources specification.
 
-*This step is not necessary for most, simply reference the Shared Tools Public releases repository in your pom*.
-
 ### Performing Maven Releases
 
 To perform a Maven release, you must have the following authorizations:
 
 1. push access to https://github.com/UWMadisonUcomm/uw-ui-toolkit.
-2. The *edu.wisc.uc - DEPLOYER* Role in the [Shared Tools Maven Artifact Repository](https://wiki.doit.wisc.edu/confluence/display/ST/Maven+Repository+Manager).
+2. Ability to publish to the `edu.wisc.uc` groupId in Maven Central. These permissions are maintained by [Sonatype](http://central.sonatype.org/pages/ossrh-guide.html). Contact the developers of this project if you'd like to request access.
 
 Once those grants are in place:
 
 1. Set the `upstreamVersion` property in pom.xml to match the latest release available at https://github.com/UWMadisonUcomm/uw-ui-toolkit/releases.
-3. Verify the build succeeds with a *mvn install*
-4. If successful, continue the release:
+2. Verify the build succeeds with a *mvn install*
+3. If successful, continue the release:
     1. *mvn release:prepare*
     2. *mvn release:perform*
     

--- a/README-Maven.md
+++ b/README-Maven.md
@@ -32,7 +32,7 @@ the target directory, and repack with the folders in the correct locations per t
 To perform a Maven release, you must have the following authorizations:
 
 1. push access to https://github.com/UWMadisonUcomm/uw-ui-toolkit.
-2. Ability to publish to the `edu.wisc.uc` groupId in Maven Central. These permissions are maintained by [Sonatype](http://central.sonatype.org/pages/ossrh-guide.html). Contact the developers of this project if you'd like to request access.
+2. Ability to publish to the `edu.wisc.umark` groupId in Maven Central. These permissions are maintained by [Sonatype](http://central.sonatype.org/pages/ossrh-guide.html). Contact the developers of this project if you'd like to request access.
 
 Once those grants are in place:
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,26 +1,41 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<parent>
-    	<groupId>edu.wisc.doit.code</groupId>
-    	<artifactId>shared-tools-public-parent</artifactId>
-    	<version>7</version>
-	</parent>
-	<groupId>edu.wisc.uc</groupId>
+	<groupId>edu.wisc.umark</groupId>
 	<artifactId>uw-ui-toolkit</artifactId>
-	<version>0.2.2-SNAPSHOT</version>
+	<version>0.2.2-RC2-SNAPSHOT</version>
 	<name>UW UI Toolkit</name>
 	<description>A web front-end toolkit based on Bootstrap for designing and developing modern, mobile-first websites for the University of Wisconsin-Madison.</description>
-
+	<url>https://github.com/UWMadisonUcomm/uw-ui-toolkit</url>
+	
 	<organization>
 		<name>University of Wisconsin-Madison</name>
 		<url>http://www.wisc.edu</url>
 	</organization>
+	
+	<licenses>
+		<license>
+			<name>Apache License, Version 2.0</name>
+			<url>https://www.apache.org/licenses/LICENSE-2.0</url>
+		</license>
+	</licenses>
+	
 	<scm>
 		<url>https://github.com/UWMadisonUcomm/uw-ui-toolkit</url>
 		<connection>scm:git:https://github.com/UWMadisonUcomm/uw-ui-toolkit.git</connection>
 		<developerConnection>scm:git:https://github.com/UWMadisonUcomm/uw-ui-toolkit.git</developerConnection>
 		<tag>HEAD</tag>
 	</scm>
+	
+	<distributionManagement>
+		<snapshotRepository>
+			<id>ossrh</id>
+			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
+		</snapshotRepository>
+		<repository>
+			<id>ossrh</id>
+			<url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+		</repository>
+	</distributionManagement>
 	
 	<developers>
 		<developer>
@@ -40,16 +55,9 @@
 		</contributor>
 	</contributors>
 
-	<repositories>
-	    <repository>
-	        <id>code.doit-public-releases</id>
-	        <url>https://code.doit.wisc.edu/maven/content/repositories/public-releases/</url>
-	    </repository>
-	</repositories>
-
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<upstreamVersion>0.2.1</upstreamVersion>
+		<upstreamVersion>0.2.2</upstreamVersion>
 		<sourceRootUrl>https://github.com/UWMadisonUcomm/uw-ui-toolkit/releases/download/v${upstreamVersion}</sourceRootUrl>
 		<destDir>${project.build.outputDirectory}/META-INF/resources/${project.groupId}/${project.artifactId}/${upstreamVersion}</destDir>
 	</properties>
@@ -75,6 +83,7 @@
 				</executions>
 			</plugin>
 			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-antrun-plugin</artifactId>
                 <version>1.7</version>
                 <executions>
@@ -99,19 +108,48 @@
         		<artifactId>maven-release-plugin</artifactId>
         		<version>2.5</version>
         		<configuration>
+        			<!-- disable 'release' profile from super pom -->
+        			<useReleaseProfile>false</useReleaseProfile>
+   					<releaseProfiles>ossrh-release</releaseProfiles>
+    				<goals>deploy</goals>
           			<tagNameFormat>@{project.artifactId}-maven-@{project.version}</tagNameFormat>
         		</configuration>
       		</plugin>
-      		<plugin>
-				<groupId>com.mycila.maven-license-plugin</groupId>
-				<artifactId>maven-license-plugin</artifactId>
+			<plugin>
+				<groupId>org.sonatype.plugins</groupId>
+				<artifactId>nexus-staging-maven-plugin</artifactId>
+				<version>1.6.3</version>
+				<extensions>true</extensions>
 				<configuration>
-					<includes>
-						<include>${destDir}/css/**</include>
-						<include>${destDir}/js/**</include>
-					</includes>
+					<serverId>ossrh</serverId>
+					<nexusUrl>https://oss.sonatype.org/</nexusUrl>
+					<autoReleaseAfterClose>true</autoReleaseAfterClose>
 				</configuration>
 			</plugin>
 		</plugins>
 	</build>
+
+	<profiles>
+		<profile>
+			<id>ossrh-release</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-gpg-plugin</artifactId>
+						<version>1.5</version>
+						<executions>
+							<execution>
+								<id>sign-artifacts</id>
+								<phase>verify</phase>
+								<goals>
+									<goal>sign</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 </project>


### PR DESCRIPTION
This pull request completes Issue #62 and changes the groupId to `edu.wisc.umark`.
Hoping to get another set of eyes on the change before pushing to master.

References:

* http://central.sonatype.org/pages/apache-maven.html
* http://central.sonatype.org/pages/requirements.html