### PR TITLE
Add width:auto to fix padding on input groups in widgets

### DIFF
--- a/src/less/uw-ui-toolkit/my-uw/widget.less
+++ b/src/less/uw-ui-toolkit/my-uw/widget.less
@@ -9,6 +9,7 @@
 }
 .widget-body .input-group {
   margin:10px 10px 30px;
+  width:auto;
   .fa {
     font-size:18px;
   }


### PR DESCRIPTION
Goes along with https://github.com/UW-Madison-DoIT/angularjs-portal/commit/6acf1d165aba89990684b0b75dc019b0788ea3b0 in angularjs-portal to fix the padding on input groups in widgets. 

Now:
![image](https://cloud.githubusercontent.com/assets/1919535/10146924/e02ef428-65f0-11e5-99d4-82ac2e534e3f.png)
