### PR TITLE
Get rid of FontAwesome widget sizes

### DIFF
--- a/src/less/uw-ui-toolkit/my-uw/widget.less
+++ b/src/less/uw-ui-toolkit/my-uw/widget.less
@@ -1,17 +1,10 @@
 /* Widget Styles */
 
-.widget-body .fa {
-  font-size:14px;
-  padding:0px;
-}
 .input-group input {
   border:0px solid transparent;
 }
 .widget-body .input-group {
-  margin:10px 10px 30px;
-  .fa {
-    font-size:18px;
-  }
+  margin:10px auto 30px;
 }
 .widget-body .icon-button-div {
   padding:0px 0px 10px 0px;
@@ -31,7 +24,6 @@
 
   a .fa {
     color:#fff;
-    font-size:24px;
   }
 }
 
@@ -77,11 +69,6 @@
     }
   }
 }
-
-
-
-
-
 
 .widget-frame {
   position:relative;


### PR DESCRIPTION
Now we can use the FA size classes on elements directly, also cleaned up padding on input-group to maintain previous amounts.  Address https://github.com/UWMadisonUcomm/uw-ui-toolkit/issues/90

Note: this will require adding the "fa-lg" class to ALL input-group buttons AND circle buttons ( pre-directive, as the directive already does this ).  However, they don't look that horrible with a smaller icon :100:  