### PR TITLE
Remove forced icon font size in widget for My UW

### DIFF
--- a/src/less/uw-ui-toolkit/my-uw/widget.less
+++ b/src/less/uw-ui-toolkit/my-uw/widget.less
@@ -98,7 +98,6 @@
       color:#333;
       vertical-align:middle;
       padding:30px 10px;
-      font-size:70px;
     }
   }
   p {


### PR DESCRIPTION
Back to draconian font awesome font sizes, this time on an innocent looking `i` tag.  hehe :100: 

Now adding font-awesome sizes to widget icons works; original size of 70px can be replicated via `fa-5x` class on the icon itself ( = 5em ).

As with the last widget related pull request, this one will require adding the `fa-5x` class to all widgets to maintain current sizes.