### PR TITLE
Tweak the RRPG example for brevity of link labels.

### DIFF
--- a/my-uw/index.md
+++ b/my-uw/index.md
@@ -288,13 +288,13 @@ slug: my-uw
                "actionParameter":"q",
                "launchText":"Go to resource guide",
                "links":[{
-                     "title":"Get started at the Initiate Phase",
+                     "title":"Get started",
                      "href":"https://rprg.wisc.edu/phases/initiate/",
                      "icon":"fa-map-o",
                      "target":"_blank"
                   },
                   {
-                     "title":"Resource List",
+                     "title":"Resources",
                      "href":"https://rprg.wisc.edu/category/resource/",
                      "icon":"fa-th-list",
                      "target":"_blank"


### PR DESCRIPTION
Lead with brief labels in the widget example to encourage brevity in labels in widgets developed working from the example.
